### PR TITLE
feat: Update logic to create a booking

### DIFF
--- a/db/migration/V1__create_properties_table.sql
+++ b/db/migration/V1__create_properties_table.sql
@@ -4,6 +4,8 @@ CREATE TABLE IF NOT EXISTS properties
     external_id VARCHAR(12) NOT NULL UNIQUE,
     description VARCHAR(250) NOT NULL,
     alias VARCHAR(50) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 1,
+    status VARCHAR(50) NOT NULL DEFAULT 'AVAILABLE',
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );

--- a/src/main/java/com/hostfully/app/booking/exception/ConcurrentBookingException.java
+++ b/src/main/java/com/hostfully/app/booking/exception/ConcurrentBookingException.java
@@ -1,0 +1,7 @@
+package com.hostfully.app.booking.exception;
+
+public class ConcurrentBookingException extends RuntimeException {
+    public ConcurrentBookingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hostfully/app/booking/usecase/CreateBooking.java
+++ b/src/main/java/com/hostfully/app/booking/usecase/CreateBooking.java
@@ -65,14 +65,10 @@ public class CreateBooking {
         final PropertyEntity propertyEntity = getProperty(booking.getPropertyId());
 
         try {
-            if (propertyEntity.getStatus().isBooked())
-                throw new OverlapBookingException("We’re unable to process your booking for this property. "
-                        + "Please refresh the page or try again later.");
-
             // Explicitly save the property to increment version, ensuring concurrent bookings for the same property
             // fail
             propertyEntity.setStatus(PropertyEntityStatus.BOOKED);
-            propertyRepository.save(propertyEntity);
+            propertyRepository.saveAndFlush(propertyEntity);
 
             final Booking bookingResult =
                     BookingMapper.toDomain(bookingRepository.save(BookingMapper.toEntity(booking, propertyEntity)));

--- a/src/main/java/com/hostfully/app/infra/entity/PropertyEntity.java
+++ b/src/main/java/com/hostfully/app/infra/entity/PropertyEntity.java
@@ -1,6 +1,8 @@
 package com.hostfully.app.infra.entity;
 
 import jakarta.persistence.*;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +12,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PropertyEntity extends Auditable {
 
     @Id
@@ -19,6 +22,13 @@ public class PropertyEntity extends Auditable {
     @Column(name = "external_id")
     private String externalId;
 
+    @Enumerated(EnumType.STRING)
+    @Column
+    private PropertyEntityStatus status;
+
+    @Version
+    private Long version;
+
     private String description;
     private String alias;
 
@@ -26,5 +36,25 @@ public class PropertyEntity extends Auditable {
         this.externalId = externalId;
         this.description = description;
         this.alias = alias;
+        this.status = PropertyEntityStatus.AVAILABLE;
+    }
+
+    public enum PropertyEntityStatus {
+        AVAILABLE,
+        BLOCKED,
+        BOOKED;
+
+        public static PropertyEntityStatus fromString(String value) {
+            if (value == null) return null;
+
+            return Arrays.stream(PropertyEntityStatus.values())
+                    .filter(e -> e.name().equalsIgnoreCase(value))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid SessionType: " + value));
+        }
+
+        public boolean isBooked() {
+            return this == BOOKED;
+        }
     }
 }

--- a/src/main/java/com/hostfully/app/infra/repository/BookingRepository.java
+++ b/src/main/java/com/hostfully/app/infra/repository/BookingRepository.java
@@ -4,6 +4,7 @@ import com.hostfully.app.infra.entity.BookingEntity;
 import com.hostfully.app.infra.entity.BookingEntity.BookingStatus;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -46,4 +47,7 @@ public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
 
     @Query("SELECT b FROM BookingEntity b LEFT JOIN FETCH b.property where b.externalId = :externalId")
     Optional<BookingEntity> findByExternalId(String externalId);
+
+    @Query("SELECT b FROM BookingEntity b LEFT JOIN FETCH b.property p where p.externalId = :externalId")
+    List<BookingEntity> findByProperty(String externalId);
 }

--- a/src/test/java/com/hostfully/app/booking/usecase/OverlapBookingServiceTest.java
+++ b/src/test/java/com/hostfully/app/booking/usecase/OverlapBookingServiceTest.java
@@ -1,0 +1,111 @@
+package com.hostfully.app.booking.usecase;
+
+import static com.hostfully.app.booking.usecase.CreateBooking.CreateBookingCommand;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.hostfully.app.availability.service.AvailabilityService;
+import com.hostfully.app.booking.domain.Booking;
+import com.hostfully.app.booking.exception.ConcurrentBookingException;
+import com.hostfully.app.infra.entity.PropertyEntity;
+import com.hostfully.app.infra.repository.BookingRepository;
+import com.hostfully.app.infra.repository.PropertyRepository;
+import com.hostfully.app.shared.IdempotencyService;
+import com.hostfully.app.shared.util.NanoIdGenerator;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class OverlapBookingServiceTest {
+
+    @Autowired
+    private IdempotencyService idempotencyService;
+
+    @Autowired
+    private NanoIdGenerator nanoIdGenerator;
+
+    @Autowired
+    private AvailabilityService availabilityService;
+
+    @Autowired
+    private PropertyRepository propertyRepository;
+
+    @Autowired
+    private BookingRepository bookingRepository;
+
+    private final LocalDate startDate = LocalDate.now();
+    private final LocalDate endDate = LocalDate.now().plusDays(1);
+    private final String propertyId = "PROP-001";
+
+    @BeforeEach
+    void setup() {
+        propertyRepository.save(new PropertyEntity(propertyId, "Beach House", "Beach baby!"));
+    }
+
+    @Test
+    @DisplayName("ensure that the system won't overlap a booking")
+    void ensureNoOverbookingTest() throws InterruptedException, ExecutionException {
+        final CreateBookingCommand command1 =
+                createCommand(UUID.randomUUID(), propertyId, startDate, endDate, "user-1");
+        final CreateBookingCommand command2 =
+                createCommand(UUID.randomUUID(), propertyId, startDate, endDate, "user-2");
+
+        final CreateBooking spyCreateBooking = Mockito.spy(new CreateBooking(
+                idempotencyService, nanoIdGenerator, availabilityService, propertyRepository, bookingRepository));
+
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        Callable<Booking> task1 = () -> {
+            latch.await();
+            return spyCreateBooking.execute(command1);
+        };
+
+        Callable<Booking> task2 = () -> {
+            latch.await();
+            return spyCreateBooking.execute(command2);
+        };
+
+        final Future<Booking> result1 = executor.submit(task1);
+        final Future<Booking> result2 = executor.submit(task2);
+
+        latch.countDown();
+
+        Booking booking1 = null;
+        Booking booking2 = null;
+        Exception exception = null;
+
+        try {
+            booking1 = result1.get();
+        } catch (ExecutionException e) {
+            exception = (Exception) e.getCause();
+        }
+
+        try {
+            booking2 = result2.get();
+        } catch (ExecutionException e) {
+            exception = (Exception) e.getCause();
+        }
+
+        Assertions.assertTrue((booking1 != null && booking2 == null && exception instanceof ConcurrentBookingException)
+                || (booking2 != null && booking1 == null && exception instanceof ConcurrentBookingException));
+
+        verify(spyCreateBooking, times(1)).execute(command1);
+        verify(spyCreateBooking, times(1)).execute(command2);
+
+        executor.shutdown();
+    }
+
+    private CreateBooking.CreateBookingCommand createCommand(
+            UUID idempotencyKey, String propertyId, LocalDate startDate, LocalDate endDate, String guest) {
+        return new CreateBooking.CreateBookingCommand(propertyId, startDate, endDate, guest, 2, idempotencyKey);
+    }
+}

--- a/src/test/java/com/hostfully/app/infra/respository/BlockRepositoryTest.java
+++ b/src/test/java/com/hostfully/app/infra/respository/BlockRepositoryTest.java
@@ -36,10 +36,9 @@ public class BlockRepositoryTest {
     void setUp() {
         property1 = entityManager.persist(new PropertyEntity("PROP-001", "Beach House", "Beach baby!"));
         property2 = entityManager.persist(new PropertyEntity("PROP-002", "Mountain Cabin", "Relax time"));
+        entityManager.flush();
 
         createAndSaveBlock("asert-1234", property2, LocalDate.of(2025, 2, 5), LocalDate.of(2025, 2, 15));
-
-        entityManager.flush();
     }
 
     @ParameterizedTest

--- a/src/test/resources/logback-spring.xml
+++ b/src/test/resources/logback-spring.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <logger name="org.hibernate.SQL" level="WARN" />
+
+</configuration>


### PR DESCRIPTION
I tried a different approach here. Introducing the concept of a status property, which allows me to update the version. Now, if two threads compete for the same property, only one will be able to complete successfully.
Of course, I need to update other parts of the system to support this concept. I believe the best approach could be the merge between what was implemented [here](https://github.com/raphaeladrien/hostfully/pull/5) and this. If I need to pick one. Would be this one, only because is more reliable.

PS: I didn't use something as CascadeType.ALL, because I don't like to have many side management the lifecycle of one side.. In this case, I don't think that make sense Booking or Block (not implemented yet) management the Property entity, even from domain perspective. It is a case that I believe is better to add a couple of extra lines of code instead of let it to be management by ORM framework.